### PR TITLE
Suggestion to mention higher-degree Legendre PRF and suitability for ZKP, and to make references consistent

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,4 +4,4 @@ title: About
 permalink: /about/
 ---
 
-The aim of this website is to inform the community about new developments around the Legendre pseudo-random function, which is a PRF that is extremely well suited for secure multi-party computation (MPC) over arithmetic circuits.
+The aim of this website is to inform the community about new developments around the Legendre pseudo-random function, which is a PRF that is extremely well suited for secure multi-party computation (MPC) and zero-knowledge proofs (ZKP) over arithmetic circuits.

--- a/bounties.md
+++ b/bounties.md
@@ -79,7 +79,7 @@ For each of the challenges, $$2^{20}$$ bits of output from the Legendre PRF are 
 * [Damgård, Ivan Bjerre: On The Randomness of Legendre and Jacobi Sequences (1988)](https://link.springer.com/content/pdf/10.1007%2F0-387-34799-2_13.pdf)
 * [Lorenzo Grassi, Christian Rechberger, Dragos Rotaru, Peter Scholl, Nigel P. Smart: MPC-Friendly Symmetric Key Primitives (2016)](https://eprint.iacr.org/2016/542.pdf)
 * [Alexander Russell, Igor Shparlinski: Classical and Quantum Polynomial Reconstruction via Legendre Symbol Evaluation (2002)](https://arxiv.org/pdf/quant-ph/0212016.pdf)
-* [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound](https://eprint.iacr.org/2019/862.pdf)
-* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations](https://eprint.iacr.org/2019/1357)
-* [Novak Kaluđerović, Thorsten Kleinjung and Dušan Kostić: Cryptanalysis of the generalised Legendre pseudorandom function](https://msp.org/obs/2020/4/p17.xhtml)
+* [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound (2019)](https://eprint.iacr.org/2019/862.pdf)
+* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357)
+* [Novak Kaluđerović, Thorsten Kleinjung and Dušan Kostić: Cryptanalysis of the generalised Legendre pseudorandom function (2020)](https://msp.org/obs/2020/4/p17.xhtml)
 

--- a/bounties.md
+++ b/bounties.md
@@ -80,6 +80,6 @@ For each of the challenges, $$2^{20}$$ bits of output from the Legendre PRF are 
 * [Lorenzo Grassi, Christian Rechberger, Dragos Rotaru, Peter Scholl, Nigel P. Smart: MPC-Friendly Symmetric Key Primitives (2016)](https://eprint.iacr.org/2016/542.pdf)
 * [Alexander Russell, Igor Shparlinski: Classical and Quantum Polynomial Reconstruction via Legendre Symbol Evaluation (2002)](https://arxiv.org/pdf/quant-ph/0212016.pdf)
 * [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound (2019)](https://eprint.iacr.org/2019/862.pdf)
-* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357)
+* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357.pdf)
 * [Novak Kaluđerović, Thorsten Kleinjung and Dušan Kostić: Cryptanalysis of the generalised Legendre pseudorandom function (2020)](https://msp.org/obs/2020/4/p17.xhtml)
 

--- a/index.md
+++ b/index.md
@@ -10,7 +10,7 @@ The Legendre pseudo-random function is a one-bit PRF $$\mathbb{F}_p \rightarrow 
 
 $$ \displaystyle L_{p, K}(x) = \left\lceil\frac{1}{2}\left( \left(\frac{K + x}{p}\right) + 1\right)\right\rceil $$
 
-There are also variants of Legendre PRF with higher degree, which replaces $$K+x$$ above with a univariate polynomial $$f_K(x)$$ of degree two or more, where $K$ represents its coefficients.
+There are also variants of Legendre PRF with a higher degree, which replaces $$K+x$$ above with a univariate polynomial $$f_K(x)$$ of degree two or more, where $$K$$ represents its coefficients.
 
 ## Suitability for MPC
 
@@ -30,17 +30,15 @@ To compute the Legendre symbol $$\left[\left(\frac{x}{p}\right)\right]$$ for an 
 
 ## Suitability for ZKP
 
-Similarly, the evaluation of this PRF can be proved in ZKP over $$\mathbb{F}_{p}$$ efficiently.
-
-Let $n$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
+Similarly, the evaluation of this PRF can be proved in ZKP over $$\mathbb{F}_{p}$$ efficiently. Let $$n$$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
 
 1. Prove in ZKP that $$b(1 - b) = 0$$
 
-2. For $$b = 0$$, compute $$a = \sqrt{nx}$$; for $$b = 1$$, compute $$a = \sqrt{x}$$
+2. For $$b = 0$$, compute $$a = \sqrt{n(K + x)}$$; for $$b = 1$$, compute $$a = \sqrt{K + x}$$
 
 3. Allocate $$a$$ as a witness to the ZKP protocol
    
-4. Prove in ZKP that $$a^2 = na(1 - b) + ab$$
+4. Prove in ZKP that $$a^2 = (1 - b)nx + bx$$
 
 ## Bounties
 
@@ -57,4 +55,5 @@ Because of its suitability for MPCs, the Legendre PRF is used in a construction 
 * [Lorenzo Grassi, Christian Rechberger, Dragos Rotaru, Peter Scholl, Nigel P. Smart: MPC-Friendly Symmetric Key Primitives (2016)](https://eprint.iacr.org/2016/542.pdf)
 * [Alexander Russell, Igor Shparlinski: Classical and Quantum Polynomial Reconstruction via Legendre Symbol Evaluation (2002)](https://arxiv.org/pdf/quant-ph/0212016.pdf)
 * [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound (2019)](https://eprint.iacr.org/2019/862.pdf)
-* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357)
+* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357.pdf)
+* [Novak Kaluđerović, Thorsten Kleinjung and Dušan Kostić: Cryptanalysis of the generalised Legendre pseudorandom function (2020)](https://msp.org/obs/2020/4/p17.xhtml)

--- a/index.md
+++ b/index.md
@@ -30,7 +30,7 @@ To compute the Legendre symbol $$\left[\left(\frac{x}{p}\right)\right]$$ for an 
 
 ## Suitability for ZKP
 
-Similarly, the evaluation of this PRF can be proved in ZKP over $$\mathbb{F}_{p}$$ efficiently. Let $$n$$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
+Similarly, the evaluation of this PRF can be proved efficiently in ZKP over $$\mathbb{F}_{p}$$. Let $$n$$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
 
 1. Prove in ZKP that $$b(1 - b) = 0$$
 
@@ -38,7 +38,7 @@ Similarly, the evaluation of this PRF can be proved in ZKP over $$\mathbb{F}_{p}
 
 3. Allocate $$a$$ as a witness to the ZKP protocol
    
-4. Prove in ZKP that $$a^2 = (1 - b)nx + bx$$
+4. Prove in ZKP that $$a^2 = ((1 - b)n + b)\cdot (K+x)$$
 
 ## Bounties
 

--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ To compute the Legendre symbol $$\left[\left(\frac{x}{p}\right)\right]$$ for an 
 
 Similarly, the evaluation of this PRF can be proved efficiently in ZKP over $$\mathbb{F}_{p}$$. Let $$n$$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
 
-1. Prove in ZKP that $$b(1 - b) = 0$$
+1. Prove in ZKP that $$b\cdot (1 - b) = 0$$
 
 2. For $$b = 0$$, compute $$a = \sqrt{n(K + x)}$$; for $$b = 1$$, compute $$a = \sqrt{K + x}$$
 

--- a/index.md
+++ b/index.md
@@ -10,6 +10,8 @@ The Legendre pseudo-random function is a one-bit PRF $$\mathbb{F}_p \rightarrow 
 
 $$ \displaystyle L_{p, K}(x) = \left\lceil\frac{1}{2}\left( \left(\frac{K + x}{p}\right) + 1\right)\right\rceil $$
 
+There are also variants of Legendre PRF with higher degree, which replaces $$K+x$$ above with a univariate polynomial $$f_K(x)$$ of degree two or more, where $K$ represents its coefficients.
+
 ## Suitability for MPC
 
 Thanks to a result by Grassi et al. (2016), we know that this PRF can be evaluated very efficiently in arithmetic circuit multi-party computations (MPCs). Due to the multiplicative property of the Legendre symbol, a multiplication by a random square does not change the result of an evaluation. By additionally blinding with a random bit, the Legendre symbol can be evaluated using only three multiplications, two of which can be done offline (before the input is known).
@@ -26,6 +28,20 @@ To compute the Legendre symbol $$\left[\left(\frac{x}{p}\right)\right]$$ for an 
 
 5. The result of the computation is $$y = u (2 [b] -1 )$$
 
+## Suitability for ZKP
+
+Similarly, the evaluation of this PRF can be proved in ZKP over $$\mathbb{F}_{p}$$ efficiently.
+
+Let $n$ be any quadratic nonresidue in $$\mathbb{F}_{p}$$. To validate $$L_{p, K}(x) = b$$ for $$x, b \in \mathbb{F}_p$$:
+
+1. Prove in ZKP that $$b(1 - b) = 0$$
+
+2. For $$b = 0$$, compute $$a = \sqrt{nx}$$; for $$b = 1$$, compute $$a = \sqrt{x}$$
+
+3. Allocate $$a$$ as a witness to the ZKP protocol
+   
+4. Prove in ZKP that $$a^2 = na(1 - b) + ab$$
+
 ## Bounties
 
 Because of its suitability for MPCs, the Legendre PRF is used in a construction for the Ethereum 2.0 protocol. In order to encourage research in this PRF, we announced some bounties at Crypto'19. See [bounties](bounties).
@@ -40,5 +56,5 @@ Because of its suitability for MPCs, the Legendre PRF is used in a construction 
 * [Damgård, Ivan Bjerre: On The Randomness of Legendre and Jacobi Sequences (1988)](https://link.springer.com/content/pdf/10.1007%2F0-387-34799-2_13.pdf)
 * [Lorenzo Grassi, Christian Rechberger, Dragos Rotaru, Peter Scholl, Nigel P. Smart: MPC-Friendly Symmetric Key Primitives (2016)](https://eprint.iacr.org/2016/542.pdf)
 * [Alexander Russell, Igor Shparlinski: Classical and Quantum Polynomial Reconstruction via Legendre Symbol Evaluation (2002)](https://arxiv.org/pdf/quant-ph/0212016.pdf)
-* [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound](https://eprint.iacr.org/2019/862.pdf)
-* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations](https://eprint.iacr.org/2019/1357)
+* [Dmitry Khovratovich: Key recovery attacks on the Legendre PRFs within the birthday bound (2019)](https://eprint.iacr.org/2019/862.pdf)
+* [Ward Beullens, Tim Beyne, Aleksei Udovenko, Giuseppe Vitto: Cryptanalysis of the Legendre PRF and generalizations (2019)](https://eprint.iacr.org/2019/1357)


### PR DESCRIPTION
This PR proposes three improvements to the website:

- Mention that Legendre PRF also has values for ZKP protocols
- Mention briefly the existence of higher-degree Legendre PRF, "There are also variants of Legendre PRF with a higher degree, which replaces $$K+x$$ above with a univariate polynomial $$f_K(x)$$ of degree two or more, where $$K$$ represents its coefficients."
- Make the references in `index.md` and `bounties.md` consistent.

What do you think? I configured this PR such that maintainers can edit the files in this PR directly.

One potential next step is to supply a summary of recent results regarding how to choose good keys for higher-degree Legendre PRF, mostly from the paper by Kaluđerović, Kleinjung, and Kostić, and likely an estimator of security.